### PR TITLE
fix: broken build on macos

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -29,9 +29,12 @@ pub fn build(b: *std.Build) void {
                 "sha256_avx_x1.S",
                 "sha256_sse_x1.S",
             },
-        .flags = &[_][]const u8{
+        .flags = if (target.result.os.tag == .macos) &[_][]const u8{
             "-g",
             "-fpic",
+        } else &[_][]const u8{
+            "-g",
+            "-fPIC",
             "-fno-integrated-as",
         },
     });


### PR DESCRIPTION
**Motivation**
- got this issue when I run "zig build test" on my laptop

```
error: error(compilation): clang failed with stderr: zig: error: assembler command failed with exit code 1 (use -v to see invocation)
```