### PR TITLE
build: conditionally include `-fno-integrated-as` option depending on architecture

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -11,6 +11,14 @@ pub fn build(b: *std.Build) void {
         .link_libc = true,
     });
 
+    const assembly_flags_default = &.{ "-g", "-fpic" };
+    var assembly_flags = std.ArrayList([]const u8).init(b.allocator);
+    assembly_flags.appendSlice(assembly_flags_default) catch unreachable;
+
+    if (!target.result.cpu.arch.isAARCH64()) {
+        assembly_flags.append("-fno-integrated-as") catch unreachable;
+    }
+
     // Add the assembly and C source files
     module.addCSourceFiles(.{
         .root = b.path("hashtree/src"),
@@ -29,11 +37,7 @@ pub fn build(b: *std.Build) void {
                 "sha256_avx_x1.S",
                 "sha256_sse_x1.S",
             },
-        .flags = &[_][]const u8{
-            "-g",
-            "-fpic",
-            "-fno-integrated-as",
-        },
+        .flags = assembly_flags.items,
     });
 
     module.addCSourceFile(.{


### PR DESCRIPTION
Fixes builds for aarch64 by conditionally excluding assembly if on ARM via `-fno-integrated-as` option as found in the original [Makefile](https://github.com/OffchainLabs/hashtree/blob/e86a8b136a199f65baf604a658860a0c19a494c6/src/Makefile#L84-L88).

Related: https://github.com/ChainSafe/hashtree-z/pull/1