### PR TITLE
fix: build static library with PIC

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -13,6 +13,7 @@ pub fn build(b: *std.Build) void {
             .target = target,
             .optimize = optimize,
             .link_libc = true,
+            .pic = true,
         }),
     });
 


### PR DESCRIPTION
## What changed

Build the hashtree static library with position-independent code enabled.

## Why

The static library is linked into native Node.js shared libraries such as `@chainsafe/lodestar-z`. Cross-compiling that addon for `aarch64-linux-musl` currently fails with AArch64 relocation errors and asks for the hashtree C objects to be recompiled with `-fPIC`.

The assembly sources already receive `-fpic`; setting the Zig module's `pic` option also covers the C sources and makes the complete shared-library link valid.

## Impact

This unblocks ARM64 musl/Alpine native addon builds while preserving the existing static-library interface.

## Validation

- `zig fmt --check .`
- `zig build test`
- `zig build -Dtarget=aarch64-linux-musl`
- complete Lodestar-Z `aarch64-unknown-linux-musl` ReleaseSafe cross-build

> This PR was written with AI assistance.
